### PR TITLE
revert PYTHONPATH to PyGObject

### DIFF
--- a/installer/tools/Env.ps1
+++ b/installer/tools/Env.ps1
@@ -26,11 +26,13 @@ param(
 
 # Define the paths you want to add
 $newPath = "${installPath}\bin"
+$newPythonPath = "${installPath}\lib\site-packages"
 
 Write-Output "installPath : $installPath"
 
-# Get current PATH 
+# Get current PATH and PYTHONPATH
 $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$currentPythonPath = [Environment]::GetEnvironmentVariable("PYTHONPATH", "User")
 
 # Update PATH if the new path is not already in it
 if (-not $currentPath.Contains($newPath)) {
@@ -38,6 +40,17 @@ if (-not $currentPath.Contains($newPath)) {
     [Environment]::SetEnvironmentVariable("Path", $currentPath, "User")
 }
 Write-Verbose "Updated PATH: $currentPath"
+
+# Update PYTHONPATH if the new path is not already in it
+if (-not $currentPythonPath -or (-not $currentPythonPath.Contains($newPythonPath))) {
+    if ($currentPythonPath) {
+        $currentPythonPath += ";$newPythonPath"
+    } else {
+        $currentPythonPath = $newPythonPath
+    }
+    [Environment]::SetEnvironmentVariable("PYTHONPATH", $currentPythonPath, "User")
+}
+Write-Verbose "Updated PYTHONPATH: $currentPythonPath"
 
 # Update SENSING_DEV_ROOT if the new path is not already in it
 [Environment]::SetEnvironmentVariable("SENSING_DEV_ROOT", $installPath, "User")


### PR DESCRIPTION
Currently Both Aravis Python Binding and PyGObject is in SDK, so reverted PYTHONPATH to access the module.