### PR TITLE
Uodate installer.ps1 : Fix InstallOpenCV open behaviour

### DIFF
--- a/installer/tools/installer.ps1
+++ b/installer/tools/installer.ps1
@@ -293,7 +293,7 @@ function Invoke-Script {
     }
     Write-Verbose "installPath = $installPath"
     $installerName = "sensing-dev"
-    $installerPostfixName = if ($InstallOpenCV) { "-no-opencv" } else { "" }
+    $installerPostfixName = if ($InstallOpenCV) { "" } else { "-no-opencv" }
     $script:Url = $Url
     # Construct download URL if not provided
     if (-not $Url -and -not $LocalInstaller) {


### PR DESCRIPTION
Fixes #70 

v[24.01.04 ](https://github.com/Sensing-Dev/sensing-dev-installer/releases/tag/v24.01.04)$installerPostfixName = if ($InstallOpenCV) { "-no-opencv" } else { "" }  but in [v24.01.03-test](https://github.com/Sensing-Dev/sensing-dev-installer/releases/tag/v24.01.03-test). $installerPostfixName = if ($InstallOpenCV) { "" } else { "-no-opencv" }