### PR TITLE
updated ion-kit version to 1.8.0

### DIFF
--- a/installer/config.yml
+++ b/installer/config.yml
@@ -34,10 +34,10 @@ libraries:
     src_path: ion-kit
     install_path: install/ion-kit
     action: download # can be 'download', 'build', or 'use_existing'
-    pkg_url: "https://github.com/fixstars/ion-kit/releases/download/v1.6.0/ion-kit-1.6.0-x86-64-windows.zip"
-    pkg_sha: "eabe0c629b3d2f2e4f36587d84350c8577b0f34610f415077edb55d57e0e6718"
+    pkg_url: "https://github.com/fixstars/ion-kit/releases/download/v1.8.0/ion-kit-1.8.0-x86-64-windows.zip"
+    pkg_sha: "846ebafbacce9f805acb2f69b8710b0115672b78e64c420f35a9eab44d856282"
     git_repo: "https://github.com/fixstars/ion-kit.git"
-    version: "v1.6.0"
+    version: "v1.8.0"
 
   opencv:
     name: opencv

--- a/installer/tools/setup.sh
+++ b/installer/tools/setup.sh
@@ -23,6 +23,7 @@ fi
 
 unset ion_kit_config
 declare -A ion_kit_config=( # Declare an associative array with default values
+    ["v24.04.00"]="v1.8.0"
     ["v24.01.04"]="v1.6.0"
     ["v24.01.03"]="v1.5.1"
     ["v24.01.02"]="v1.4.0"


### PR DESCRIPTION
Update ion-kit to 1.8.0

Note that Sensing-Dev support ion-kit >= 1.7.0 on Ubuntu
