### PR TITLE
fixed aravis hash on v0.8.31 (no-gst)

### DIFF
--- a/.github/workflows/develop-Linux.yml
+++ b/.github/workflows/develop-Linux.yml
@@ -186,10 +186,10 @@ jobs:
           pip install opencv-python
           pip install aravis-python
 
-      - name: Test Aravis
-        run: |
-          cd ${{ github.workspace }}/download/installer/testcases/python
-          python aravis_test.py
+      # - name: Test Aravis
+      #   run: |
+      #     cd ${{ github.workspace }}/download/installer/testcases/python
+      #     python aravis_test.py
 
       - name: Test ion-kit
         run: |

--- a/.github/workflows/develop-Linux.yml
+++ b/.github/workflows/develop-Linux.yml
@@ -184,12 +184,12 @@ jobs:
           pip install gendc-python==$gendc_separator_version
           pip install numpy
           pip install opencv-python
+          pip install aravis-python
 
-      # - name: Test Aravis
-      #   run: |
-      #     export GI_TYPELIB_PATH=/opt/sensing-dev/lib/x86_64-linux-gnu/girepository-1.0:$GI_TYPELIB_PATH
-      #     cd ${{ github.workspace }}/download/installer/testcases/python
-      #     python aravis_test.py
+      - name: Test Aravis
+        run: |
+          cd ${{ github.workspace }}/download/installer/testcases/python
+          python aravis_test.py
 
       - name: Test ion-kit
         run: |

--- a/.github/workflows/develop-Windows.yml
+++ b/.github/workflows/develop-Windows.yml
@@ -148,17 +148,17 @@ jobs:
           }
 
       - name: Check if arv.h exists
-      run: |
-        $SENSING_DEV_ROOT= [Environment]::GetEnvironmentVariable("SENSING_DEV_ROOT", "User")
-        $include_dir = Join-Path -Path "$SENSING_DEV_ROOT" -ChildPath "include"
-        $arv_inc_dir = Join-Path -Path "$include_dir" -ChildPath "aravis-0.8"
-        $target_file = Join-Path -Path "$arv_inc_dir" -ChildPath "arv.h"
-        if (Test-Path $target_file){
-          echo "arv.h exists."
-        } else{
-          echo "arv.h does not exist."
-          exit 1
-        }
+        run: |
+          $SENSING_DEV_ROOT= [Environment]::GetEnvironmentVariable("SENSING_DEV_ROOT", "User")
+          $include_dir = Join-Path -Path "$SENSING_DEV_ROOT" -ChildPath "include"
+          $arv_inc_dir = Join-Path -Path "$include_dir" -ChildPath "aravis-0.8"
+          $target_file = Join-Path -Path "$arv_inc_dir" -ChildPath "arv.h"
+          if (Test-Path $target_file){
+            echo "arv.h exists."
+          } else{
+            echo "arv.h does not exist."
+            exit 1
+          }
 
       - name: Test Aravis installation and Path
         run: |

--- a/.github/workflows/develop-Windows.yml
+++ b/.github/workflows/develop-Windows.yml
@@ -242,11 +242,11 @@ jobs:
           pip install numpy
           pip install opencv-python
           pip install aravis-python
-          
-      - name: Test Aravis
-        run: |
-          cd ${{ github.workspace }}/download/installer/testcases/python
-          python aravis_test.py
+
+      # - name: Test Aravis
+      #   run: |
+      #     cd ${{ github.workspace }}/download/installer/testcases/python
+      #     python aravis_test.py
 
       - name: Test ion-kit
         run: |

--- a/.github/workflows/develop-Windows.yml
+++ b/.github/workflows/develop-Windows.yml
@@ -241,11 +241,12 @@ jobs:
           pip install gendc-python==$gendc_separator_version
           pip install numpy
           pip install opencv-python
-
-      # - name: Test Aravis
-      #   run: |
-      #     cd ${{ github.workspace }}/download/installer/testcases/python
-      #     python aravis_test.py
+          pip install aravis-python
+          
+      - name: Test Aravis
+        run: |
+          cd ${{ github.workspace }}/download/installer/testcases/python
+          python aravis_test.py
 
       - name: Test ion-kit
         run: |

--- a/.github/workflows/develop-Windows.yml
+++ b/.github/workflows/develop-Windows.yml
@@ -147,6 +147,19 @@ jobs:
             exit 1
           }
 
+      - name: Check if arv.h exists
+      run: |
+        $SENSING_DEV_ROOT= [Environment]::GetEnvironmentVariable("SENSING_DEV_ROOT", "User")
+        $include_dir = Join-Path -Path "$SENSING_DEV_ROOT" -ChildPath "include"
+        $arv_inc_dir = Join-Path -Path "$include_dir" -ChildPath "aravis-0.8"
+        $target_file = Join-Path -Path "$arv_inc_dir" -ChildPath "arv.h"
+        if (Test-Path $target_file){
+          echo "arv.h exists."
+        } else{
+          echo "arv.h does not exist."
+          exit 1
+        }
+
       - name: Test Aravis installation and Path
         run: |
           $PATH =  [Environment]::GetEnvironmentVariable("PATH", "User")

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -1,7 +1,7 @@
 libraries:
   aravis:
     name: aravis
-    pkg_sha: "8f4fff574eb0ec809882977d679baea101a7fb59b68411435b245ae3d7b6dc54"
+    pkg_sha: "d593e1d3af223957d384288166f0cee0f5f3648f07a2b52e7149816c03cd2ebe"
     git_repo: "https://github.com/Sensing-Dev/aravis.git"
     version: "v0.8.31"
 

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -1,21 +1,15 @@
 libraries:
   aravis:
     name: aravis
-    pkg_sha: "d593e1d3af223957d384288166f0cee0f5f3648f07a2b52e7149816c03cd2ebe"
+    pkg_sha: "7d540ed479514c74adeb2ccb8d0626bcf93077cdedb4f5f91640203054960fdc"
     git_repo: "https://github.com/Sensing-Dev/aravis.git"
     version: "v0.8.31"
 
   aravis_dep:
     name: aravis_dep
-    pkg_sha: "2b68d3d61da13aaf3af9897f2b205c2a93ebe3ff49dc757a95265bb656cd2d97"
+    pkg_sha: "ceb7685e8e9c46be7fc1791ce5be66513e2aa45eb2920164e1eb4c84dbe0eba7"
     git_repo: "" # use recipe here for appropriate version
     version: "v0.8.31"
-
-  pygobject:
-    name: pygobject
-    pkg_sha: "eea9465b7cbf1420ee3b3d8a78f6cfa3feeff89ffade7ab1874ebb25d7078037"
-    git_repo: "https://gitlab.gnome.org/GNOME/pygobject.git"
-    version: "3.42.2"
 
   ion_kit:
     name: ion-kit

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -1,13 +1,13 @@
 libraries:
   aravis:
     name: aravis
-    pkg_sha: "7d540ed479514c74adeb2ccb8d0626bcf93077cdedb4f5f91640203054960fdc"
+    pkg_sha: "a215a9b5d5d86b5eac9b970f2a17fe4b0238f458a5730a33f9c513bb9cfbc39e"
     git_repo: "https://github.com/Sensing-Dev/aravis.git"
     version: "v0.8.31"
 
   aravis_dep:
     name: aravis_dep
-    pkg_sha: "ceb7685e8e9c46be7fc1791ce5be66513e2aa45eb2920164e1eb4c84dbe0eba7"
+    pkg_sha: "8a59d45af9682eab1ca90156e4aa131a4fd6d840d0096cb6b3704d81f538ec56"
     git_repo: "" # use recipe here for appropriate version
     version: "v0.8.31"
 

--- a/installer/testcases/cpp/aravis_test/CMAKELists.txt
+++ b/installer/testcases/cpp/aravis_test/CMAKELists.txt
@@ -8,7 +8,10 @@ set(SENSING_DEV_DIR $ENV{SENSING_DEV_ROOT})
 # aravis
 include_directories(${SENSING_DEV_DIR}/include/aravis-0.8)
 include_directories(${SENSING_DEV_DIR}/include/glib-2.0)
+# v24.08 or later
 include_directories(${SENSING_DEV_DIR}/lib/glib-2.0/include)
+# v24.05 or earlier
+include_directories(${SENSING_DEV_DIR}/include/glib-2.0/include)
 link_directories(${SENSING_DEV_DIR}/bin)
 link_directories(${SENSING_DEV_DIR}/lib)
 

--- a/installer/testcases/cpp/aravis_test/CMAKELists.txt
+++ b/installer/testcases/cpp/aravis_test/CMAKELists.txt
@@ -8,7 +8,7 @@ set(SENSING_DEV_DIR $ENV{SENSING_DEV_ROOT})
 # aravis
 include_directories(${SENSING_DEV_DIR}/include/aravis-0.8)
 include_directories(${SENSING_DEV_DIR}/include/glib-2.0)
-include_directories(${SENSING_DEV_DIR}/include/glib-2.0/include)
+include_directories(${SENSING_DEV_DIR}/lib/glib-2.0/include)
 link_directories(${SENSING_DEV_DIR}/bin)
 link_directories(${SENSING_DEV_DIR}/lib)
 

--- a/installer/testcases/python/aravis_test.py
+++ b/installer/testcases/python/aravis_test.py
@@ -1,8 +1,3 @@
-import os
-os.add_dll_directory(os.path.join(os.environ["SENSING_DEV_ROOT"], "bin"))
-
-import gi
-gi.require_version("Aravis", "0.8")
-from gi.repository import Aravis
+from aravis import Aravis
 
 Aravis.update_device_list()

--- a/installer/tools/installer.ps1
+++ b/installer/tools/installer.ps1
@@ -517,7 +517,19 @@ function Invoke-Script {
         }
     
         CheckComponentHash -compName $compName -archivePath $archiveName -expectedHash $compHash
-        Expand-Archive -Path $archiveName -DestinationPath $tempExtractionPath 
+        Expand-Archive -Path $archiveName -DestinationPath $tempExtractionPath/$compName
+
+        if ($key -eq "aravis"){
+          MergeComponents -CompDirName $tempExtractionPath/$compName -tempInstallPath $tempInstallPath
+        }elseif ($key -eq "aravis_dep"){
+          MergeComponents -CompDirName $tempExtractionPath/$compName -tempInstallPath "$tempInstallPath/bin"
+        }elseif ($key -eq "ion_kit"){
+          $version_without_v = $compVersion.Substring(1)
+          $dir_name = "ion-kit-$version_without_v-x86-64-windows"
+          MergeComponents -CompDirName $tempExtractionPath/$compName/$dir_name -tempInstallPath "$tempInstallPath"
+        }elseif ($key -eq "gendc_separator"){
+          MergeComponents -CompDirName $tempExtractionPath/$compName -tempInstallPath "$tempInstallPath/include/gendc_separator"
+        }
 
       } else {
         throw "Component $key does not exist in $configFileName"
@@ -528,23 +540,7 @@ function Invoke-Script {
         Remove-Item -Force $archiveName
       }
     }
-      
-
-
-    Get-ChildItem $tempExtractionPath -Directory |
-    Foreach-Object {
-      $CompDirName = $_.FullName
-
-      if ($_.Name -eq "gendc_separator"){
-        # GenDC Separator is a header library.
-        # Move all contents under gendc_separator to under $tempInstallPath/include/gendc_separator 
-        MergeComponents -CompDirName $CompDirName -tempInstallPath "$tempInstallPath/include/gendc_separator"
-      }else{
-        # Move all contents under $CompDirName to under $tempInstallPath
-        MergeComponents -CompDirName $CompDirName -tempInstallPath $tempInstallPath
-      }  
-      
-    }
+    
 
     ################################################################################
     # Dlownload OpenCV to $tempWorkDir & extract to $tempExtractionPath

--- a/installer/tools/installer.ps1
+++ b/installer/tools/installer.ps1
@@ -517,16 +517,16 @@ function Invoke-Script {
         }
     
         CheckComponentHash -compName $compName -archivePath $archiveName -expectedHash $compHash
-        Expand-Archive -Path $archiveName -DestinationPath $tempExtractionPath/$compName
+        Expand-Archive -Path $archiveName -DestinationPath $tempExtractionPath
 
         if ($key -eq "aravis"){
           MergeComponents -CompDirName $tempExtractionPath/$compName -tempInstallPath $tempInstallPath
         }elseif ($key -eq "aravis_dep"){
-          MergeComponents -CompDirName $tempExtractionPath/$compName -tempInstallPath "$tempInstallPath/bin"
+          MergeComponents -CompDirName "$tempExtractionPath/aravis_dependencies" -tempInstallPath $tempInstallPath
         }elseif ($key -eq "ion_kit"){
           $version_without_v = $compVersion.Substring(1)
           $dir_name = "ion-kit-$version_without_v-x86-64-windows"
-          MergeComponents -CompDirName $tempExtractionPath/$compName/$dir_name -tempInstallPath "$tempInstallPath"
+          MergeComponents -CompDirName $tempExtractionPath/$dir_name -tempInstallPath $tempInstallPath
         }elseif ($key -eq "gendc_separator"){
           MergeComponents -CompDirName $tempExtractionPath/$compName -tempInstallPath "$tempInstallPath/include/gendc_separator"
         }


### PR DESCRIPTION
### Fixed the hash of aravis package.

* aravis is now v0.8.31 https://github.com/Sensing-Dev/aravis/releases/tag/v0.8.31
* aravis dependencies are now v0.8.31 https://github.com/Sensing-Dev/aravis/releases/tag/v0.8.31


### TODO (not on this PR)
* add python test (requires PyGObject on Windows)
* add gst-plugin test