### PR TITLE
update/aravis-0.8.30-internal.1

### DIFF
--- a/installer/config.yml
+++ b/installer/config.yml
@@ -4,20 +4,20 @@ libraries:
     src_path: aravis
     install_path: install/aravis
     action: download # can be 'download', 'build', or 'use_existing'
-    pkg_url: "https://github.com/Sensing-Dev/aravis/releases/download/internal-0.8.30/aravis-internal-0.8.30-win64.zip"
-    pkg_sha: "1f0ef68a9d33f9bb0c53361131bf73d67ffd3ebb4140758d914489884da93b97"
+    pkg_url: "https://github.com/Sensing-Dev/aravis/releases/download/v0.8.30-internal.1/aravis-0.8.30-internal.1-x86-64-windows.zip"
+    pkg_sha: "b78cc27c9e8b65b2eafdb27a4fd7140690b8afe1ee4bb0b8864194b470373539"
     git_repo: "https://github.com/Sensing-Dev/aravis.git"
-    version: "0.8.30-internal"
+    version: "v0.8.30-internal.1"
 
   aravis_dep:
     name: aravis_dep
     src_path: aravis_dep
     install_path: install/aravis_dep
     action: download # can be 'download', 'build', or 'use_existing'
-    pkg_url: "https://github.com/Sensing-Dev/aravis/releases/download/internal-0.8.30/Aravis-0.8.30-internal-dependencies.zip"
-    pkg_sha: "79a3a94c56d65fc63312cbb258f48be542993543fb74a33aaa8ab7ebc5c76354"
+    pkg_url: "https://github.com/Sensing-Dev/aravis/releases/download/v0.8.30-internal.1/aravis-0.8.30-internal.1-dependencies_update.zip"
+    pkg_sha: "a016fbdbcd1641471e3b222473c8cdac514092788656c7ff90cfd14e3ee1b059"
     git_repo: "https://github.com/conan-io/conan-center-index.git" # use recipe here for appropriate version
-    version: "0.8.30-internal"
+    version: "v0.8.30-internal.1"
 
   pygobject:
     name: pygobject

--- a/installer/tools/setup.sh
+++ b/installer/tools/setup.sh
@@ -50,6 +50,24 @@ declare -A gendc_separator_config=( # Declare an associative array with default 
     ["v24.05.11"]="v0.2.8"
 )
 
+unset aravis_config
+declare -A aravis_config=( # Declare an associative array with default values
+    ["v24.05.04"]="0.8.30-internal"
+    ["v24.05.05"]="0.8.30-internal"
+    ["v24.05.06"]="0.8.30-internal"
+    ["v24.05.07"]="0.8.30-internal"
+    ["v24.05.08"]="0.8.30-internal"
+    ["v24.05.09"]="0.8.30-internal"
+    ["v24.05.10"]="0.8.30-internal"
+    ["v24.05.11"]="v0.8.30-internal.1"
+)
+
+unset aravis_url
+declare -A aravis_url=( # Declare an associative array with default values
+    ["0.8.30-internal"]="https://github.com/Sensing-Dev/aravis/releases/download/internal-0.8.30/aravis-internal-0.8.30-x86-64-linux.tar.gz"
+    ["v0.8.30-internal.1"]="https://github.com/Sensing-Dev/aravis/releases/download/v0.8.30-internal.1/aravis-0.8.30-internal.1-x86-64-linux.tar.gz"
+)
+
 EARLIEST_STABLE_SDK="v24.05.04"
 
 INSTALL_PATH=/opt/sensing-dev
@@ -113,6 +131,8 @@ fi
 
 ION_KIT_VERSION=${ion_kit_config["$Alt_Version"]}
 GENDC_SEPARATOR_VERSION=${gendc_separator_config["$Alt_Version"]}
+ARAVIS_VERSION=${aravis_config["$Alt_Version"]}
+ARAVIS_URL=${aravis_url["$ARAVIS_VERSION"]}
 
 mkdir -p $INSTALL_PATH
 
@@ -130,10 +150,10 @@ apt-get -y upgrade && apt-get update && apt-get install -y curl gzip git python3
 
 echo
 echo "**********"
-echo "Install aravis=0.8.30"
+echo "Install aravis=${ARAVIS_VERSION}"
 echo "**********"
 
-curl -L https://github.com/Sensing-Dev/aravis/releases/download/internal-0.8.30/aravis-internal-0.8.30-x86-64-linux.tar.gz| tar zx -C $INSTALL_PATH --strip-components 1
+curl -L ${ARAVIS_URL}| tar zx -C $INSTALL_PATH --strip-components 1
 mkdir -p /etc/udev/rules.d
 cat > /etc/udev/rules.d/80-aravis.rules << EOS
 SUBSYSTEM=="usb", ATTRS{idVendor}=="054c", MODE:="0666", TAG+="uaccess", TAG+="udev-acl"


### PR DESCRIPTION
- [x] Update Aravis version on config.yml (Windows)
- [x] Update Aravis version on setup.sh (Linux)
- [x] Update setup.sh to set Aravis version `0.8.30-internal` for v24.05.10 or earlier and `v0.8.30-internal.1` for v24.05.11 or later